### PR TITLE
feat(workouts): add batch generator + validator + dedupe

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1,0 +1,165 @@
+// scripts/build/config.ts
+// Shared types, enums, caps, and helper maps for generator/validator.
+
+export type Level = 'beginner' | 'intermediate' | 'advanced';
+export type Goal = 'strength' | 'conditioning' | 'fat_loss' | 'mobility';
+export type Pattern = 'squat' | 'hinge' | 'push' | 'pull' | 'core' | 'gait';
+export type Equipment =
+  | 'bodyweight'
+  | 'dumbbell'
+  | 'barbell'
+  | 'kettlebell'
+  | 'machine'
+  | 'cable'
+  | 'band'
+  | 'medicine_ball'
+  | 'sled'
+  | 'cardio'
+  | 'other';
+
+export interface Exercise {
+  id: string;            // canonical slug id (lowercase-kebab)
+  name: string;
+  category?: string;
+  equipment?: string[];  // raw equipment tags
+  primaryMuscles?: string[];
+  secondaryMuscles?: string[];
+  language?: string;
+}
+
+export interface WorkoutItem {
+  exerciseId: string;
+  sets?: number;
+  reps?: number | string;
+  timeSec?: number;
+  tempo?: string; // e.g., "31X1"
+  restSec?: number;
+  rpe?: number;   // 6–9 typical
+}
+
+export interface WorkoutBlock {
+  type: 'warmup' | 'strength' | 'metcon' | 'finisher' | 'cooldown';
+  style?: 'Strength' | 'AMRAP' | 'EMOM' | 'ForTime' | 'Intervals' | 'Circuit';
+  timeSec?: number; // for metcon/intervals/emom
+  items: WorkoutItem[];
+}
+
+export interface Workout {
+  id: string;
+  slug: string;
+  title: string;
+  goal: Goal;
+  level: Level;
+  durationMin: 20 | 30 | 45 | 60;
+  location: 'gym' | 'home' | 'outdoor';
+  equipment: Equipment[];
+  blocks: WorkoutBlock[];
+  notes?: string;
+  media?: { cover: string | null };
+  language?: 'nl' | 'en';
+  tags?: string[];
+  progression?: { microcycleWeek?: 1 | 2 | 3 | 4; type?: 'load' | 'density' | 'variation' };
+}
+
+// --- Global Config ---
+
+export const DURATIONS: Array<Workout['durationMin']> = [20, 30, 45, 60];
+export const LEVELS: Level[] = ['beginner', 'intermediate', 'advanced'];
+export const GOALS: Goal[] = ['strength', 'conditioning', 'fat_loss', 'mobility'];
+export const EQUIPMENT_PROFILES: Equipment[][] = [
+  ['bodyweight'],
+  ['dumbbell'],
+  ['kettlebell'],
+  ['barbell'],
+  ['machine'],
+  ['dumbbell', 'kettlebell', 'bodyweight'], // mixed light
+  ['barbell', 'machine', 'dumbbell'], // mixed gym
+];
+
+export const FORBIDDEN_TERMS = [
+  // Keep content brand-safe (incl. user preference: avoid specific event names)
+  /hyrox/i,
+];
+
+export const MIN_PATTERN_COVERAGE = 3 as const;
+
+// Bandbreedtes per doel/level (rust/tempo/RPE caps)
+export const REST_BANDS: Record<Goal, Record<Level, [number, number]>> = {
+  strength: { beginner: [75, 120], intermediate: [90, 150], advanced: [90, 180] },
+  conditioning: { beginner: [20, 45], intermediate: [15, 40], advanced: [10, 30] },
+  fat_loss: { beginner: [20, 45], intermediate: [15, 40], advanced: [10, 30] },
+  mobility: { beginner: [0, 20], intermediate: [0, 20], advanced: [0, 20] },
+};
+
+export const RPE_BANDS: Record<Goal, Record<Level, [number, number]>> = {
+  strength: { beginner: [6, 8], intermediate: [7, 9], advanced: [7, 9] },
+  conditioning: { beginner: [6, 7], intermediate: [6, 8], advanced: [7, 9] },
+  fat_loss: { beginner: [6, 7], intermediate: [6, 8], advanced: [7, 8] },
+  mobility: { beginner: [3, 6], intermediate: [3, 6], advanced: [3, 6] },
+};
+
+export const TEMPOS: Record<Goal, string[]> = {
+  strength: ['31X1', '30X1', '21X1', '22X1'],
+  conditioning: ['20X1', '11X1', '10X1'],
+  fat_loss: ['20X1', '21X1', '11X1'],
+  mobility: ['2020', '3030', '4040'],
+};
+
+// Volume caps per sessie (harde sets) per duur/level
+export const VOLUME_CAPS: Record<Level, Record<Workout['durationMin'], number>> = {
+  beginner: { 20: 9, 30: 12, 45: 16, 60: 20 },
+  intermediate: { 20: 10, 30: 14, 45: 18, 60: 22 },
+  advanced: { 20: 12, 30: 16, 45: 22, 60: 26 },
+};
+
+// Conflict rules (simple): avoid repeating same heavy pattern back-to-back in strength
+export const HEAVY_PATTERNS: Pattern[] = ['squat', 'hinge'];
+
+// --- Helpers to normalize equipment/patterns from exercises ---
+
+export function normalizeEquipmentTag(tag?: string): Equipment {
+  const t = (tag || '').toLowerCase();
+  if (/(bodyweight|no equipment|none)/.test(t)) return 'bodyweight';
+  if (/dumbbell|db/.test(t)) return 'dumbbell';
+  if (/barbell|bb|trap bar/.test(t)) return 'barbell';
+  if (/kettlebell|kb/.test(t)) return 'kettlebell';
+  if (/machine|leg press|smith/.test(t)) return 'machine';
+  if (/cable/.test(t)) return 'cable';
+  if (/band|resistance band/.test(t)) return 'band';
+  if (/medicine ball|med ball|slam ball/.test(t)) return 'medicine_ball';
+  if (/sled|prowler/.test(t)) return 'sled';
+  if (/run|row|bike|erg|treadmill|skierg/.test(t)) return 'cardio';
+  return 'other';
+}
+
+export function derivePatternsFromMuscles(muscles: string[] = []): Set<Pattern> {
+  const m = muscles.map((s) => s.toLowerCase());
+  const p = new Set<Pattern>();
+  if (m.some((x) => /quad|glute/.test(x))) p.add('squat');
+  if (m.some((x) => /hamstring|glute|erector/.test(x))) p.add('hinge');
+  if (m.some((x) => /chest|triceps|shoulder|deltoid/.test(x))) p.add('push');
+  if (m.some((x) => /back|lat|bicep|rear delt|trap/.test(x))) p.add('pull');
+  if (m.some((x) => /ab|core|oblique|lower abs|transverse/.test(x))) p.add('core');
+  return p;
+}
+
+export function derivePatternsFromName(name: string): Set<Pattern> {
+  const n = name.toLowerCase();
+  const p = new Set<Pattern>();
+  if (/(squat|lunge|step-up|pistol)/.test(n)) p.add('squat');
+  if (/(deadlift|hinge|good morning|hip thrust|rdl|kettle.*swing)/.test(n)) p.add('hinge');
+  if (/(press|push-up|dip|overhead)/.test(n)) p.add('push');
+  if (/(row|pull-up|chin-up|pulldown|face pull)/.test(n)) p.add('pull');
+  if (/(plank|crunch|sit-up|raise|pallof|hollow|dead bug|rotation|anti-rotation)/.test(n)) p.add('core');
+  if (/(run|sprint|carry|farmer|walk|sled)/.test(n)) p.add('gait');
+  return p;
+}
+
+export function derivePatterns(ex: Exercise): Pattern[] {
+  const set = new Set<Pattern>();
+  derivePatternsFromMuscles([...(ex.primaryMuscles || []), ...(ex.secondaryMuscles || [])]).forEach((p) => set.add(p));
+  derivePatternsFromName(ex.name || '').forEach((p) => set.add(p));
+  // Heuristics for gait/carry
+  if ((ex.name || '').toLowerCase().includes('carry')) set.add('gait');
+  return Array.from(set);
+}

--- a/scripts/build/generate-workouts.ts
+++ b/scripts/build/generate-workouts.ts
@@ -1,0 +1,517 @@
+// scripts/build/generate-workouts.ts
+// Batch generator: template-combinator + variant matrix + validator + dedupe + export.
+
+import fs from 'fs';
+import path from 'path';
+
+import {
+  Exercise,
+  Workout,
+  WorkoutBlock,
+  WorkoutItem,
+  Level,
+  Goal,
+  Pattern,
+  Equipment,
+  DURATIONS,
+  LEVELS,
+  GOALS,
+  EQUIPMENT_PROFILES,
+  RPE_BANDS,
+  REST_BANDS,
+  TEMPOS,
+  derivePatterns,
+  normalizeEquipmentTag,
+} from './config';
+import { signatureTokens, jaccardSim, djb2 } from './signature';
+import { validateWorkout, ExerciseMap } from './validator';
+
+// --- CLI args ---
+const argv = process.argv.slice(2);
+const getArg = (k: string, fallback?: string) => {
+  const hit = argv.find((a) => a.startsWith(`--${k}=`));
+  return hit ? hit.split('=')[1] : fallback;
+};
+
+const VERSION = (getArg('version') || new Date().toISOString().slice(0, 10).replace(/-/g, '')).replace(/^v?/, '');
+const TARGET = parseInt(getArg('target') || '1500', 10);
+const CHUNK_SIZE = parseInt(getArg('chunk', ) || '400', 10);
+const SEED = getArg('seed') || 'fitprove';
+
+// --- Seeded RNG (mulberry32) ---
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rng = mulberry32(djb2(SEED));
+
+// --- Load exercises ---
+function loadExercises(): Exercise[] {
+  const localPath = path.resolve('scripts/build/assets/exercises.json'); // fallback
+  const envUrl = process.env.EXERCISEDB_JSON_URL || '';
+  // We prefer local file to avoid network in build.
+  if (fs.existsSync(localPath)) {
+    const raw = JSON.parse(fs.readFileSync(localPath, 'utf-8'));
+    // support {exercises:[...]} or [...]
+    return Array.isArray(raw) ? raw : (raw.exercises || []);
+  }
+  if (!envUrl) {
+    console.warn('No exercises file found and EXERCISEDB_JSON_URL not set. Please add scripts/build/assets/exercises.json');
+    return [];
+  }
+  // Simple remote fetch using node >=18
+  return []; // avoid network fetch in most envs; rely on local file/pipeline
+}
+
+// Build indexes: by equipment & pattern
+type IndexedExercise = Exercise & {
+  equipmentNorm: Equipment[];
+  patterns: Pattern[];
+};
+
+function indexExercises(exs: Exercise[]) {
+  const idx: {
+    byId: ExerciseMap;
+    byPattern: Record<Pattern, IndexedExercise[]>;
+    byEquip: Record<Equipment, IndexedExercise[]>;
+  } = {
+    byId: new Map(),
+    byPattern: { squat: [], hinge: [], push: [], pull: [], core: [], gait: [] },
+    byEquip: {
+      bodyweight: [], dumbbell: [], barbell: [], kettlebell: [], machine: [],
+      cable: [], band: [], medicine_ball: [], sled: [], cardio: [], other: [],
+    },
+  };
+
+  for (const ex of exs) {
+    const equipmentNorm: Equipment[] = (ex.equipment || []).map(normalizeEquipmentTag);
+    if (equipmentNorm.length === 0) equipmentNorm.push('bodyweight');
+    const patterns = derivePatterns(ex);
+    const ix: IndexedExercise = { ...ex, equipmentNorm, patterns };
+
+    idx.byId.set(ex.id, ex);
+    patterns.forEach((p) => idx.byPattern[p].push(ix));
+    equipmentNorm.forEach((e) => idx.byEquip[e].push(ix));
+  }
+  return idx;
+}
+
+// Utility: pick N distinct by predicate
+function pickN<T>(arr: T[], n: number): T[] {
+  const out: T[] = [];
+  const used = new Set<number>();
+  let attempts = 0;
+  while (out.length < n && attempts < arr.length * 3) {
+    const i = Math.floor(rng() * arr.length);
+    if (!used.has(i)) {
+      used.add(i);
+      out.push(arr[i]);
+    }
+    attempts++;
+  }
+  return out;
+}
+
+// Build items helpers
+function makeStrengthItem(ex: Exercise, level: Level, goal: Goal): WorkoutItem {
+  const [rpeMin, rpeMax] = RPE_BANDS[goal][level];
+  const tempo = TEMPOS[goal][Math.floor(rng() * TEMPOS[goal].length)];
+  const sets = level === 'beginner' ? 3 : level === 'intermediate' ? 4 : 5;
+  const reps = goal === 'strength' ? (level === 'advanced' ? '4-6' : '6-8') : '8-12';
+  const [restMin, restMax] = REST_BANDS[goal][level];
+  const rest = Math.round(restMin + rng() * (restMax - restMin));
+  const rpe = Math.round((rpeMin + rng() * (rpeMax - rpeMin)) * 10) / 10;
+  return { exerciseId: ex.id, sets, reps, tempo, restSec: rest, rpe };
+}
+
+function makeTimedItem(ex: Exercise, secs: number): WorkoutItem {
+  return { exerciseId: ex.id, timeSec: secs };
+}
+
+// --- Template families (functions that produce blocks) ---
+
+type VariantCtx = {
+  level: Level;
+  goal: Goal;
+  duration: Workout['durationMin'];
+  equipProfile: Equipment[];
+};
+
+type FamilyBuilder = (pool: IndexedPools, v: VariantCtx) => WorkoutBlock[] | null;
+
+type IndexedPools = {
+  byPattern: Record<Pattern, IndexedExercise[]>;
+  byEquip: Record<Equipment, IndexedExercise[]>;
+  any: IndexedExercise[];
+};
+
+function poolsFromIndex(idx: ReturnType<typeof indexExercises>, profile: Equipment[]): IndexedPools {
+  const any: IndexedExercise[] = [];
+  Object.values(idx.byEquip).forEach((arr) => any.push(...arr));
+  // Filter by allowed equipment profile
+  const filt = (arr: IndexedExercise[]) => arr.filter((x) => x.equipmentNorm.some((e) => profile.includes(e)));
+  const byPattern: any = {};
+  (['squat', 'hinge', 'push', 'pull', 'core', 'gait'] as Pattern[]).forEach((p) => (byPattern[p] = filt(idx.byPattern[p])));
+  const byEquip: any = {};
+  Object.keys(idx.byEquip).forEach((k) => (byEquip[k as Equipment] = filt(idx.byEquip[k as Equipment])));
+  return { byPattern, byEquip, any: filt(any) };
+}
+
+// FB Strength+Metcon
+const familyFullBody: FamilyBuilder = (pool, v) => {
+  const squat = pickN(pool.byPattern.squat, 1)[0];
+  const hinge = pickN(pool.byPattern.hinge, 1)[0];
+  const push = pickN(pool.byPattern.push, 1)[0];
+  const pull = pickN(pool.byPattern.pull, 1)[0];
+  const core = pickN(pool.byPattern.core, 1)[0];
+  if (!squat || !hinge || !push || !pull || !core) return null;
+
+  const warmup: WorkoutBlock = {
+    type: 'warmup',
+    style: 'Circuit',
+    timeSec: 5 * 60,
+    items: [makeTimedItem(push, 40), makeTimedItem(core, 40), makeTimedItem(hinge, 40)],
+  };
+
+  const strength: WorkoutBlock = {
+    type: 'strength',
+    style: 'Strength',
+    items: [
+      makeStrengthItem(squat, v.level, v.goal),
+      makeStrengthItem(push, v.level, v.goal),
+      makeStrengthItem(hinge, v.level, v.goal),
+    ],
+  };
+
+  const metconTime = v.duration === 60 ? 20 * 60 : v.duration === 45 ? 14 * 60 : 10 * 60;
+  const metcon: WorkoutBlock = {
+    type: 'metcon',
+    style: 'AMRAP',
+    timeSec: metconTime,
+    items: [
+      { exerciseId: push.id, reps: 10 },
+      { exerciseId: pull.id, reps: 12 },
+      { exerciseId: core.id, reps: 14 },
+    ],
+  };
+
+  const cooldown: WorkoutBlock = {
+    type: 'cooldown',
+    items: [makeTimedItem(core, 60)],
+  };
+
+  return [warmup, strength, metcon, cooldown];
+};
+
+// Upper/Lower split day
+const familyUpperLower: FamilyBuilder = (pool, v) => {
+  const lower1 = pickN(pool.byPattern.squat.concat(pool.byPattern.hinge), 2);
+  const upper = pickN(pool.byPattern.push.concat(pool.byPattern.pull), 2);
+  const core = pickN(pool.byPattern.core, 1)[0];
+  if (lower1.length < 2 || upper.length < 2 || !core) return null;
+
+  const strength: WorkoutBlock = {
+    type: 'strength',
+    style: 'Strength',
+    items: [
+      makeStrengthItem(lower1[0], v.level, v.goal),
+      makeStrengthItem(upper[0], v.level, v.goal),
+      makeStrengthItem(lower1[1], v.level, v.goal),
+      makeStrengthItem(upper[1], v.level, v.goal),
+    ],
+  };
+
+  const finisher: WorkoutBlock = {
+    type: 'finisher',
+    style: 'EMOM',
+    timeSec: v.duration >= 45 ? 10 * 60 : 6 * 60,
+    items: [{ exerciseId: core.id, reps: 12 }],
+  };
+
+  return [
+    { type: 'warmup', style: 'Circuit', timeSec: 4 * 60, items: [makeTimedItem(lower1[0], 40), makeTimedItem(upper[0], 40)] },
+    strength,
+    finisher,
+    { type: 'cooldown', items: [makeTimedItem(core, 60)] },
+  ];
+};
+
+// PPL style (condensed)
+const familyPPL: FamilyBuilder = (pool, v) => {
+  const push = pickN(pool.byPattern.push, 2);
+  const pull = pickN(pool.byPattern.pull, 2);
+  const legs = pickN(pool.byPattern.squat.concat(pool.byPattern.hinge), 2);
+  const core = pickN(pool.byPattern.core, 1)[0];
+  if (push.length < 1 || pull.length < 1 || legs.length < 1 || !core) return null;
+
+  const blocks: WorkoutBlock[] = [
+    { type: 'warmup', style: 'Circuit', timeSec: 4 * 60, items: [makeTimedItem(push[0], 40), makeTimedItem(legs[0], 40)] },
+    {
+      type: 'strength',
+      style: 'Strength',
+      items: [makeStrengthItem(push[0], v.level, v.goal), makeStrengthItem(pull[0], v.level, v.goal), makeStrengthItem(legs[0], v.level, v.goal)],
+    },
+    {
+      type: 'metcon',
+      style: 'Intervals',
+      timeSec: v.duration >= 45 ? 12 * 60 : 8 * 60,
+      items: [{ exerciseId: core.id, timeSec: 40 }, { exerciseId: pull[1]?.id || pull[0].id, timeSec: 40 }],
+    },
+    { type: 'cooldown', items: [makeTimedItem(core, 60)] },
+  ];
+  return blocks;
+};
+
+// Bodyweight AMRAP (home/outdoor)
+const familyBodyweight: FamilyBuilder = (pool, v) => {
+  const bwPush = pool.byPattern.push.filter((x) => x.equipmentNorm.includes('bodyweight'));
+  const bwSquat = pool.byPattern.squat.filter((x) => x.equipmentNorm.includes('bodyweight'));
+  const core = pool.byPattern.core.filter((x) => x.equipmentNorm.includes('bodyweight'));
+  const gait = pool.byPattern.gait;
+
+  if (bwPush.length === 0 || bwSquat.length === 0 || core.length === 0) return null;
+
+  const push = pickN(bwPush, 1)[0];
+  const squat = pickN(bwSquat, 1)[0];
+  const coreEx = pickN(core, 1)[0];
+  const carry = gait.length ? pickN(gait, 1)[0] : null;
+
+  const time = v.duration === 20 ? 8 * 60 : v.duration === 30 ? 12 * 60 : 16 * 60;
+
+  const metcon: WorkoutBlock = {
+    type: 'metcon',
+    style: 'AMRAP',
+    timeSec: time,
+    items: [
+      { exerciseId: squat.id, reps: 15 },
+      { exerciseId: push.id, reps: 12 },
+      { exerciseId: coreEx.id, reps: 16 },
+      ...(carry ? [{ exerciseId: carry.id, timeSec: 45 } as WorkoutItem] : []),
+    ],
+  };
+
+  return [
+    { type: 'warmup', style: 'Circuit', timeSec: 4 * 60, items: [makeTimedItem(squat, 30), makeTimedItem(coreEx, 30)] },
+    metcon,
+    { type: 'cooldown', items: [makeTimedItem(coreEx, 60)] },
+  ];
+};
+
+// Kettlebell Mixed (swings/press/squat)
+const familyKettlebell: FamilyBuilder = (pool, v) => {
+  const kb = (e: IndexedExercise) => e.equipmentNorm.includes('kettlebell');
+  const swings = pool.byPattern.hinge.filter(kb);
+  const press = pool.byPattern.push.filter(kb);
+  const squat = pool.byPattern.squat.filter(kb);
+  const core = pool.byPattern.core.filter(kb);
+
+  if (!swings.length || !press.length || !squat.length || !core.length) return null;
+
+  const warmup: WorkoutBlock = { type: 'warmup', style: 'Circuit', timeSec: 4 * 60, items: [makeTimedItem(squat[0], 30), makeTimedItem(core[0], 30)] };
+  const strength: WorkoutBlock = { type: 'strength', style: 'Strength', items: [makeStrengthItem(press[0], v.level, v.goal), makeStrengthItem(squat[0], v.level, v.goal)] };
+  const emom: WorkoutBlock = { type: 'metcon', style: 'EMOM', timeSec: v.duration >= 45 ? 12 * 60 : 8 * 60, items: [{ exerciseId: swings[0].id, reps: 15 }, { exerciseId: core[0].id, reps: 12 }] };
+  const cooldown: WorkoutBlock = { type: 'cooldown', items: [makeTimedItem(core[0], 60)] };
+  return [warmup, strength, emom, cooldown];
+};
+
+// Machine Circuit (gym)
+const familyMachineCircuit: FamilyBuilder = (pool, v) => {
+  const mach = (e: IndexedExercise) => e.equipmentNorm.includes('machine') || e.equipmentNorm.includes('cable');
+  const push = pool.byPattern.push.filter(mach);
+  const pull = pool.byPattern.pull.filter(mach);
+  const squat = pool.byPattern.squat.filter(mach);
+  const core = pool.byPattern.core.filter(mach).concat(pool.byPattern.core);
+
+  if (!push.length || !pull.length || !squat.length || !core.length) return null;
+
+  const circuit: WorkoutBlock = {
+    type: 'metcon',
+    style: 'Circuit',
+    timeSec: v.duration >= 45 ? 18 * 60 : 12 * 60,
+    items: [
+      { exerciseId: squat[0].id, reps: 12 },
+      { exerciseId: push[0].id, reps: 12 },
+      { exerciseId: pull[0].id, reps: 12 },
+      { exerciseId: core[0].id, reps: 15 },
+    ],
+  };
+  return [
+    { type: 'warmup', style: 'Circuit', timeSec: 4 * 60, items: [makeTimedItem(squat[0], 30), makeTimedItem(push[0], 30)] },
+    circuit,
+    { type: 'cooldown', items: [makeTimedItem(core[0], 60)] },
+  ];
+};
+
+const FAMILIES: Array<{ name: string; builder: FamilyBuilder; allow: (equip: Equipment[]) => boolean; goals?: Goal[] }> = [
+  { name: 'Full Body — Strength + Metcon', builder: familyFullBody, allow: () => true },
+  { name: 'Upper/Lower Mix', builder: familyUpperLower, allow: () => true },
+  { name: 'Push/Pull/Legs Mix', builder: familyPPL, allow: () => true },
+  { name: 'Bodyweight AMRAP', builder: familyBodyweight, allow: (e) => e.includes('bodyweight') },
+  { name: 'Kettlebell Mixed', builder: familyKettlebell, allow: (e) => e.includes('kettlebell') },
+  { name: 'Machine Circuit', builder: familyMachineCircuit, allow: (e) => e.includes('machine') || e.includes('cable') },
+];
+
+// Build workout object
+function makeWorkoutTitle(base: string, dur: Workout['durationMin'], equip: Equipment[], level: Level) {
+  const equipLabel =
+    equip.length === 1 ? (
+      equip[0] === 'bodyweight' ? 'Bodyweight' :
+      equip[0] === 'dumbbell' ? 'Dumbbells' :
+      equip[0] === 'kettlebell' ? 'Kettlebell' :
+      equip[0] === 'barbell' ? 'Barbell' :
+      equip[0] === 'machine' ? 'Machines' : equip[0]
+    ) : 'Mixed';
+  const levelLabel = level === 'beginner' ? 'beginner' : level === 'intermediate' ? 'intermediate' : 'advanced';
+  return `${base} — ${equipLabel} • ${dur} min (${levelLabel})`;
+}
+
+function toSlug(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+// --- Main orchestration ---
+function main() {
+  console.log(`[workouts] Generating version v${VERSION} with target ${TARGET}+ items…`);
+  const exList = loadExercises();
+  if (exList.length === 0) {
+    console.error('No exercises loaded. Aborting.');
+    process.exit(1);
+  }
+
+  const idx = indexExercises(exList);
+  const out: Workout[] = [];
+  const sigs: string[][] = [];
+
+  // Iterate matrix
+  outer:
+  for (const level of LEVELS) {
+    for (const goal of GOALS) {
+      for (const duration of DURATIONS) {
+        for (const equipProfile of EQUIPMENT_PROFILES) {
+          // Build pools filtered by equipment profile
+          const pools = poolsFromIndex(idx, equipProfile);
+
+          for (const fam of FAMILIES) {
+            if (!fam.allow(equipProfile)) continue;
+            const v = { level, goal, duration, equipProfile };
+            const blocks = fam.builder(pools, v);
+            if (!blocks) continue;
+
+            const baseTitle = fam.name;
+            const title = makeWorkoutTitle(baseTitle, duration, equipProfile, level);
+            const slugBase = `${baseTitle}-${duration}-${equipProfile.join('_')}-${level}-${goal}`;
+            const slug = toSlug(slugBase);
+            const id = `wkt_${slug}_${djb2(slug + VERSION).toString(16)}`;
+
+            const w: Workout = {
+              id,
+              slug,
+              title,
+              goal,
+              level,
+              durationMin: duration,
+              location: equipProfile.includes('bodyweight') ? 'home' : 'gym',
+              equipment: equipProfile,
+              blocks,
+              notes: 'Houd techniek strak; stop 1–2 reps in de tank.',
+              media: { cover: null },
+              language: 'nl',
+              tags: [fam.name.split(' ')[0], ...equipProfile, goal, level],
+              progression: { microcycleWeek: ((djb2(id) % 4) + 1) as 1 | 2 | 3 | 4, type: ['load', 'density', 'variation'][djb2(id) % 3] as any },
+            };
+
+            // Validate
+            const res = validateWorkout(w, idx.byId);
+            if (!res.ok) continue;
+
+            // Dedupe
+            const tokens = signatureTokens(w);
+            let dup = false;
+            for (const t of sigs) {
+              if (jaccardSim(t, tokens) >= 0.85) {
+                dup = true;
+                break;
+              }
+            }
+            if (dup) continue;
+
+            out.push(w);
+            sigs.push(tokens);
+            if (out.length >= TARGET) break outer;
+          }
+        }
+      }
+    }
+  }
+
+  // If still below target (unlikely), add randomized variations of families
+  let guard = 0;
+  while (out.length < TARGET && guard < TARGET * 5) {
+    guard++;
+    const level = LEVELS[Math.floor(rng() * LEVELS.length)];
+    const goal = GOALS[Math.floor(rng() * GOALS.length)];
+    const duration = DURATIONS[Math.floor(rng() * DURATIONS.length)];
+    const equipProfile = EQUIPMENT_PROFILES[Math.floor(rng() * EQUIPMENT_PROFILES.length)];
+    const pools = poolsFromIndex(idx, equipProfile);
+    const fam = FAMILIES[Math.floor(rng() * FAMILIES.length)];
+    if (!fam.allow(equipProfile)) continue;
+    const v = { level, goal, duration, equipProfile };
+    const blocks = fam.builder(pools, v);
+    if (!blocks) continue;
+
+    const baseTitle = fam.name;
+    const title = makeWorkoutTitle(baseTitle, duration, equipProfile, level);
+    const slugBase = `${baseTitle}-${duration}-${equipProfile.join('_')}-${level}-${goal}-${Math.floor(rng()*1e6)}`;
+    const slug = toSlug(slugBase);
+    const id = `wkt_${slug}_${djb2(slug + VERSION).toString(16)}`;
+    const w: Workout = {
+      id, slug, title, goal, level, durationMin: duration,
+      location: equipProfile.includes('bodyweight') ? 'home' : 'gym',
+      equipment: equipProfile, blocks,
+      notes: 'Houd techniek strak; stop 1–2 reps in de tank.',
+      media: { cover: null }, language: 'nl',
+      tags: [fam.name.split(' ')[0], ...equipProfile, goal, level],
+      progression: { microcycleWeek: ((djb2(id) % 4) + 1) as 1 | 2 | 3 | 4, type: ['load', 'density', 'variation'][djb2(id) % 3] as any },
+    };
+
+    const res = validateWorkout(w, idx.byId);
+    if (!res.ok) continue;
+
+    const tokens = signatureTokens(w);
+    let dup = false;
+    for (const t of sigs) if (jaccardSim(t, tokens) >= 0.85) { dup = true; break; }
+    if (dup) continue;
+
+    out.push(w);
+    sigs.push(tokens);
+  }
+
+  // Export
+  const basePath = path.join('public', 'data', 'workouts', `v${VERSION}`);
+  fs.mkdirSync(basePath, { recursive: true });
+
+  const manifest = {
+    version: `v${VERSION}`,
+    total: out.length,
+    chunks: Math.ceil(out.length / CHUNK_SIZE),
+    chunkSize: CHUNK_SIZE,
+    basePath,
+    generatedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(basePath, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+  for (let i = 0; i < manifest.chunks; i++) {
+    const slice = out.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+    const file = path.join(basePath, `chunk-${String(i).padStart(3, '0')}.json`);
+    fs.writeFileSync(file, JSON.stringify(slice, null, 2));
+  }
+
+  console.log(`[workouts] Done. Generated ${out.length} workouts → ${basePath}`);
+  console.log(`[workouts] Manifest:`, manifest);
+}
+
+main();

--- a/scripts/build/signature.ts
+++ b/scripts/build/signature.ts
@@ -1,0 +1,37 @@
+// scripts/build/signature.ts
+// Canonical signature + Jaccard similarity for dedupe.
+
+import { Workout } from './config';
+
+export function signatureTokens(w: Workout): string[] {
+  const tokens: string[] = [];
+  tokens.push(`goal:${w.goal}`, `level:${w.level}`, `dur:${w.durationMin}`);
+  for (const b of w.blocks) {
+    tokens.push(`b:${b.type}:${b.style || ''}:${b.timeSec || 0}`);
+    for (const it of b.items) {
+      tokens.push(`x:${it.exerciseId}`);
+      if (it.sets) tokens.push(`s:${it.sets}`);
+      if (it.reps !== undefined) tokens.push(`r:${it.reps}`);
+      if (it.timeSec) tokens.push(`t:${it.timeSec}`);
+    }
+  }
+  return tokens;
+}
+
+export function jaccardSim(a: string[], b: string[]): number {
+  const A = new Set(a);
+  const B = new Set(b);
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter++;
+  const union = A.size + B.size - inter;
+  return union === 0 ? 1 : inter / union;
+}
+
+// Simple DJB2 hash for ID/slug generation
+export function djb2(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  return hash >>> 0;
+}

--- a/scripts/build/validator.ts
+++ b/scripts/build/validator.ts
@@ -1,0 +1,118 @@
+// scripts/build/validator.ts
+// Validates workout structure, IDs, coverage, simple caps/conflicts, and forbidden terms.
+
+import {
+    Workout,
+    Exercise,
+    Pattern,
+    MIN_PATTERN_COVERAGE,
+    VOLUME_CAPS,
+    LEVELS,
+    DURATIONS,
+    RPE_BANDS,
+    REST_BANDS,
+    FORBIDDEN_TERMS,
+    HEAVY_PATTERNS,
+    derivePatterns,
+  } from './config';
+  
+  export interface ValidationIssue { code: string; message: string }
+  export interface ValidationResult { ok: boolean; issues: ValidationIssue[] }
+  
+  export type ExerciseMap = Map<string, Exercise>;
+  
+  export function validateForbiddenTerms(w: Workout): ValidationIssue[] {
+    const text = `${w.title} ${w.notes || ''}`.toLowerCase();
+    const bad = FORBIDDEN_TERMS.find((re) => re.test(text));
+    return bad ? [{ code: 'forbidden_term', message: `Found forbidden term in title/notes` }] : [];
+  }
+  
+  export function validateIdsExist(w: Workout, exMap: ExerciseMap): ValidationIssue[] {
+    const missing: string[] = [];
+    for (const b of w.blocks) {
+      for (const it of b.items) {
+        if (!exMap.has(it.exerciseId)) missing.push(it.exerciseId);
+      }
+    }
+    return missing.length ? [{ code: 'missing_exercise', message: `Missing exercise IDs: ${missing.slice(0, 5).join(', ')}` }] : [];
+  }
+  
+  export function collectPatterns(w: Workout, exMap: ExerciseMap): Set<Pattern> {
+    const p = new Set<Pattern>();
+    for (const b of w.blocks) {
+      for (const it of b.items) {
+        const ex = exMap.get(it.exerciseId);
+        if (!ex) continue;
+        derivePatterns(ex).forEach((pp) => p.add(pp));
+      }
+    }
+    return p;
+  }
+  
+  export function validatePatternCoverage(w: Workout, exMap: ExerciseMap): ValidationIssue[] {
+    const p = collectPatterns(w, exMap);
+    if (p.size < MIN_PATTERN_COVERAGE) {
+      return [{ code: 'pattern_coverage', message: `Only ${p.size} patterns covered; need ≥ ${MIN_PATTERN_COVERAGE}` }];
+    }
+    return [];
+  }
+  
+  export function validateVolumeCaps(w: Workout): ValidationIssue[] {
+    if (!LEVELS.includes(w.level) || !DURATIONS.includes(w.durationMin)) return [];
+    const cap = VOLUME_CAPS[w.level][w.durationMin];
+    let hardSets = 0;
+    for (const b of w.blocks) {
+      if (b.type === 'strength' || b.type === 'metcon' || b.type === 'finisher') {
+        for (const it of b.items) if (typeof it.sets === 'number') hardSets += it.sets;
+      }
+    }
+    return hardSets > cap ? [{ code: 'volume_cap', message: `Hard sets ${hardSets} > cap ${cap}` }] : [];
+  }
+  
+  export function validateRestRpe(w: Workout): ValidationIssue[] {
+    const issues: ValidationIssue[] = [];
+    const [rpeMin, rpeMax] = RPE_BANDS[w.goal][w.level];
+    const [restMin, restMax] = REST_BANDS[w.goal][w.level];
+    for (const b of w.blocks) {
+      for (const it of b.items) {
+        if (it.rpe !== undefined && (it.rpe < rpeMin || it.rpe > rpeMax)) {
+          issues.push({ code: 'rpe_band', message: `RPE ${it.rpe} outside [${rpeMin},${rpeMax}]` });
+        }
+        if (it.restSec !== undefined && (it.restSec < restMin || it.restSec > restMax)) {
+          issues.push({ code: 'rest_band', message: `Rest ${it.restSec}s outside [${restMin},${restMax}]` });
+        }
+      }
+    }
+    return issues;
+  }
+  
+  export function validateConflicts(w: Workout, exMap: ExerciseMap): ValidationIssue[] {
+    // Simple check: in strength block, avoid two heavy patterns (squat/hinge) back-to-back
+    for (const b of w.blocks) {
+      if (b.type !== 'strength') continue;
+      let prevHeavy = false;
+      for (const it of b.items) {
+        const ex = exMap.get(it.exerciseId);
+        if (!ex) continue;
+        const pats = new Set(derivePatterns(ex));
+        const heavy = HEAVY_PATTERNS.some((hp) => pats.has(hp));
+        if (heavy && prevHeavy) {
+          return [{ code: 'heavy_back_to_back', message: `Two heavy strength moves back-to-back` }];
+        }
+        prevHeavy = heavy;
+      }
+    }
+    return [];
+  }
+  
+  export function validateWorkout(w: Workout, exMap: ExerciseMap): ValidationResult {
+    const issues: ValidationIssue[] = [];
+    issues.push(...validateForbiddenTerms(w));
+    issues.push(...validateIdsExist(w, exMap));
+    issues.push(...validatePatternCoverage(w, exMap));
+    issues.push(...validateVolumeCaps(w));
+    issues.push(...validateRestRpe(w));
+    issues.push(...validateConflicts(w, exMap));
+    return { ok: issues.length === 0, issues };
+  }
+  


### PR DESCRIPTION
[Feature Ticket]
Doel/Acceptatiecriteria:
- [ ] Genereer ≥1500 **complete** workouts uit template-varianten (level×duur×equipment×doel×layout).
- [ ] **Validator-pass 100%**: oefening-ID bestaat, min. 3 patronen (Squat/Hinge/Push/Pull/Core/Gait), volume/tempo/rust/RPE binnen bandbreedtes.
- [ ] **Dedupe**: structure-signature + Jaccard < 0.85; <5% afgekeurd als duplicaat.
- [ ] Export: `public/data/workouts/v20250906/{manifest.json,chunk-*.json}` met ≥3 chunks; manifest bevat `version,total,chunks,chunkSize,basePath`.
- [ ] Geen verboden termen in content; NL labels aanwezig.
- [ ] App laadt nieuwe versie zonder console errors; dark mode leesbaar; mobile-first OK.
- [ ] CI/typecheck/eslint groen.

Scope & routes:
- Scripts: `scripts/build/generate-workouts.ts`, `scripts/build/validator.ts`, `scripts/build/signature.ts`, `scripts/build/config.ts`.
- Data-out: `public/data/workouts/v20250906/*` → Supabase bucket `workouts`.
- App: alleen `.env` `VITE_WORKOUTS_BASE` bump.

Assets/Links:
- Exercise Library (via `EXERCISEDB_JSON_URL` of `scripts/build/assets/exercises.json`).

Design/UX:
- Datalaag; UI only smoke test (dark mode, filters).

Techniek:
- Template-combinator (families/layouts) + variant-matrix.
- Constraint-validator (pattern coverage, caps, conflicts, tempo/rust/RPE, forbidden terms).
- Signature + Jaccard dedupe.
- Export met chunking (standaard 400).

Test:
- `npx tsx scripts/build/generate-workouts.ts --version=20250906 --target=1500`
- Controleer console rapport (counts/fails/dup-ratio/coverage).
- Upload → `.env` update → smoke test in app.

